### PR TITLE
install ome-zarr

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -9,8 +9,7 @@ dependencies:
   # ome: minimal dependencies required to use the Python API
   - omero-py
   # dependencies to use for zarr work
-  - dask
   - dask-image
   - imageio
-  - requests
-  - zarr
+  - pip:
+    - ome-zarr


### PR DESCRIPTION
Similar to https://github.com/ome/omero-guide-ilastik/pull/21 and the problem reported in https://github.com/ome/ome-zarr-py/pull/41
Use directly ``ome-zarr``
* Check that the ``zarr`` notebooks e.g. zarr-public-s3-segmentation-parallel.ipynb can be run without error

cc @joshmoore @pwalczysko 