### PR TITLE
fix installation

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,14 +2,14 @@ channels:
   - conda-forge
   - ome
 dependencies:
-  - matplotlib
-  - scikit-image
-  - scipy
+  - matplotlib=3.3.2
+  - scikit-image=0.17.2
+  - scipy=1.5.2
   - pip
   # ome: minimal dependencies required to use the Python API
   - omero-py
   # dependencies to use for zarr work
-  - dask-image
-  - imageio
+  - imageio=2.6.1
   - pip:
     - ome-zarr
+    - dask-image


### PR DESCRIPTION
Ahead of next week I was checking if it was still possible to build with the recently release version of dask-image
Installation from conda does not work anymore, I have opted to install from pypi instead
I also cap the other dependencies to avoid problems

Check that zarr-public-s3-segmentation-parallel.ipynb can be run