### PR TITLE
Action repo2docker

### DIFF
--- a/.github/workflows/repo2docker.yml
+++ b/.github/workflows/repo2docker.yml
@@ -26,6 +26,9 @@ jobs:
         shell: bash
       - name: Check no no_push_to_cache
         run: echo ${{ steps.nopush.outputs.nopush }}
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
       - name: update jupyter dependencies with repo2docker
         uses: jupyterhub/repo2docker-action@master
         with:
@@ -34,3 +37,4 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           BINDER_CACHE: true
           PUBLIC_REGISTRY_CHECK: true
+          ADDITIONAL_TAG: ${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/repo2docker.yml
+++ b/.github/workflows/repo2docker.yml
@@ -35,6 +35,5 @@ jobs:
           NO_PUSH: ${{ steps.nopush.outputs.nopush }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          BINDER_CACHE: true
           PUBLIC_REGISTRY_CHECK: true
           ADDITIONAL_TAG: ${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/repo2docker.yml
+++ b/.github/workflows/repo2docker.yml
@@ -15,7 +15,22 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - name: repo2docker install
-        run: pip install --upgrade jupyter-repo2docker
-      - name: Build container
-        run: repo2docker --no-run .
+      - name: Set no_push variable
+        id: nopush
+        run:  |
+          if [[ ${{ github.ref }} =~ 'refs/tags/' ]]; then
+            echo "::set-output name=nopush::"
+          else
+            echo "::set-output name=nopush::true"
+          fi
+        shell: bash
+      - name: Check no no_push_to_cache
+        run: echo ${{ steps.nopush.outputs.nopush }}
+      - name: update jupyter dependencies with repo2docker
+        uses: jupyterhub/repo2docker-action@master
+        with:
+          NO_PUSH: ${{ steps.nopush.outputs.nopush }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          BINDER_CACHE: true
+          PUBLIC_REGISTRY_CHECK: true

--- a/.github/workflows/repo2docker.yml
+++ b/.github/workflows/repo2docker.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Check no no_push_to_cache
         run: echo ${{ steps.nopush.outputs.nopush }}
       - name: Get the version
+        if: startsWith(github.ref, 'refs/tags')
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
       - name: update jupyter dependencies with repo2docker
@@ -37,3 +38,4 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           PUBLIC_REGISTRY_CHECK: true
           ADDITIONAL_TAG: ${{ steps.get_version.outputs.VERSION }}
+          IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/repo2docker.yml
+++ b/.github/workflows/repo2docker.yml
@@ -24,8 +24,6 @@ jobs:
             echo "::set-output name=nopush::true"
           fi
         shell: bash
-      - name: Check no no_push_to_cache
-        run: echo ${{ steps.nopush.outputs.nopush }}
       - name: Get the version
         if: startsWith(github.ref, 'refs/tags')
         id: get_version


### PR DESCRIPTION
This PR uses https://github.com/jupyterhub/repo2docker-action actions to build the repository
The image is cached on dockerhub when the repository is tagged. We could opt to do it when a PR is merged to master

I have tested the push to dockerhub see
https://hub.docker.com/r/jburel/omero-guide-python/tags

See 
https://github.com/jburel/omero-guide-python/actions/runs/534090543 and
https://github.com/jburel/omero-guide-python/actions/runs/534129704

When we are happy if the implementation, I will update https://github.com/ome/.github/blob/master/workflow-templates/repo2docker.yml
and the workflows in the various repositories using the template

Secrets will need to be added for the deployment to dockerhub.