### PR TITLE
fix table.close in batch_roi_export_to_table.py

### DIFF
--- a/scripts/batch_roi_export_to_table.py
+++ b/scripts/batch_roi_export_to_table.py
@@ -252,12 +252,14 @@ def save_table(conn, images, image_data, script_params, project=None):
     data = [img_column] + cols
     table.initialize(data)
     table.addData(data)
-    table.close()
 
     if project is None:
         log("No Project found to link table")
     else:
         link_table(conn, table, project)
+
+    # after linking, we can close
+    table.close()
 
 
 def save_map_annotations(conn, images, image_data, script_params):

--- a/scripts/batch_roi_export_to_table.py
+++ b/scripts/batch_roi_export_to_table.py
@@ -245,21 +245,23 @@ def save_table(conn, images, image_data, script_params, project=None):
     table_name = "batch_roi_export"
     table = resources.newTable(repository_id, table_name)
 
-    # Create table
-    image_ids = [i.id for i in images]
-    img_column = ImageColumn('Image', '', image_ids)
-    cols = [DoubleColumn(k, '', image_data[k]) for k in SUMMARY_COL_NAMES]
-    data = [img_column] + cols
-    table.initialize(data)
-    table.addData(data)
+    try:
+        # Create table
+        image_ids = [i.id for i in images]
+        img_column = ImageColumn('Image', '', image_ids)
+        cols = [DoubleColumn(k, '', image_data[k]) for k in SUMMARY_COL_NAMES]
+        data = [img_column] + cols
+        table.initialize(data)
+        table.addData(data)
 
-    if project is None:
-        log("No Project found to link table")
-    else:
-        link_table(conn, table, project)
+        if project is None:
+            log("No Project found to link table")
+        else:
+            link_table(conn, table, project)
 
-    # after linking, we can close
-    table.close()
+    finally:
+        # after linking, we can close
+        table.close()
 
 
 def save_map_annotations(conn, images, image_data, script_params):


### PR DESCRIPTION
See https://github.com/ome/training-scripts/pull/89/files#r688333998

This fixes a bug in `batch_roi_export_to_table.py` since we must now do `table.getOriginalFile()` before closing the table.

To test,
 - Upload script to a server
 - Run from webclient, choosing a Project, Dasetet or a few Images - *Script is designed to work with idr0021 data
 - Bulk-annotation table should be linked to the parent Project