### PR TITLE
Fix link to StarDist in notebook

### DIFF
--- a/notebooks/idr0062_prediction.ipynb
+++ b/notebooks/idr0062_prediction.ipynb
@@ -12,7 +12,7 @@
     "The image is referenced in the paper \"NesSys: a novel method for accurate nuclear segmentation in 3D\" published August 2019 in PLOS Biology: https://doi.org/10.1371/journal.pbio.3000388 and can be viewed online in the [Image Data Resource](https://idr.openmicroscopy.org/webclient/?show=image-6001247).\n",
     "\n",
     "\n",
-    "In this notebook, the image is loaded together with the labels and analyzed using [StarDist](https://stardist.net/docs/index.html). The StarDist analysis produces a segmentation, which is then viewed side-by-side with the original segmentations produced by the authors of the paper obtained via the loaded labels.\n",
+    "In this notebook, the image is loaded together with the labels and analyzed using [StarDist](https://github.com/stardist/stardist). The StarDist analysis produces a segmentation, which is then viewed side-by-side with the original segmentations produced by the authors of the paper obtained via the loaded labels.\n",
     "\n",
     "If you wish to run the notebook locally or run the corresponding [Python script](../scripts/idr0062_prediction.py), please read instruction in [README](https://github.com/ome/omero-guide-python/blob/master/README.md)."
    ]


### PR DESCRIPTION
As discussed on the call this morning, the StarDist link is 404 ing.

This is replacing the link with the github repo link.


cc @jburel 