### PR TITLE
Install ice-python wheel for Python 3.12

### DIFF
--- a/notebooks/CalculateSharpnessOneImage.ipynb
+++ b/notebooks/CalculateSharpnessOneImage.ipynb
@@ -50,9 +50,9 @@
    "outputs": [],
    "source": [
     "# Ice Python binding\n",
-    "%pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp310-cp310-manylinux_2_28_x86_64.whl\n",
+    "%pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp312-cp312-manylinux_2_28_x86_64.whl\n",
     "# Package required to interact with IDR or OMERO\n",
-    "%pip install omero-py==5.19.2"
+    "%pip install omero-py"
    ]
   },
   {
@@ -430,7 +430,7 @@
    },
    "source": [
     "### License (BSD 2-Clause)\n",
-    "Copyright (C) 2019-2024 University of Dundee. All Rights Reserved.\n",
+    "Copyright (C) 2019-2026 University of Dundee. All Rights Reserved.\n",
     "\n",
     "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:\n",
     "\n",

--- a/notebooks/IlluminationCorrectionNotebook.ipynb
+++ b/notebooks/IlluminationCorrectionNotebook.ipynb
@@ -26,9 +26,9 @@
    "outputs": [],
    "source": [
     "# Ice Python binding\n",
-    "%pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp310-cp310-manylinux_2_28_x86_64.whl\n",
+    "%pip installhttps://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp312-cp312-manylinux_2_28_x86_64.whl\n",
     "# Package required to interact with IDR or OMERO\n",
-    "%pip install omero-py==5.19.2"
+    "%pip install omero-py"
    ]
   },
   {
@@ -250,7 +250,7 @@
    },
    "source": [
     "### License (BSD 2-Clause)\n",
-    "Copyright (C) 2019-2024 University of Dundee. All Rights Reserved.\n",
+    "Copyright (C) 2019-2026 University of Dundee. All Rights Reserved.\n",
     "\n",
     "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:\n",
     "\n",

--- a/notebooks/OMEROHelloWorld.ipynb
+++ b/notebooks/OMEROHelloWorld.ipynb
@@ -31,9 +31,9 @@
    "outputs": [],
    "source": [
     "# Ice Python binding\n",
-    "%pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp310-cp310-manylinux_2_28_x86_64.whl\n",
+    "%pip installhttps://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp312-cp312-manylinux_2_28_x86_64.whl\n",
     "# Package required to interact with IDR or OMERO\n",
-    "%pip install omero-py==5.19.2"
+    "%pip install omero-py"
    ]
   },
   {
@@ -189,7 +189,7 @@
    },
    "source": [
     "### License (BSD 2-Clause)\n",
-    "Copyright (C) 2019-2024 University of Dundee. All Rights Reserved.\n",
+    "Copyright (C) 2019-2026 University of Dundee. All Rights Reserved.\n",
     "\n",
     "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:\n",
     "\n",

--- a/notebooks/SimpleFRAP.ipynb
+++ b/notebooks/SimpleFRAP.ipynb
@@ -30,9 +30,9 @@
    "outputs": [],
    "source": [
     "# Ice Python binding\n",
-    "%pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp310-cp310-manylinux_2_28_x86_64.whl\n",
+    "%pip installhttps://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp312-cp312-manylinux_2_28_x86_64.whl\n",
     "# Package required to interact with IDR or OMERO\n",
-    "%pip install omero-py==5.19.2"
+    "%pip install omero-py"
    ]
   },
   {
@@ -444,7 +444,7 @@
    "metadata": {},
    "source": [
     "### License (BSD 2-Clause)\n",
-    "Copyright (C) 2019-2024 University of Dundee. All Rights Reserved.\n",
+    "Copyright (C) 2019-2026 University of Dundee. All Rights Reserved.\n",
     "\n",
     "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:\n",
     "\n",


### PR DESCRIPTION
Install ice-python wheel for Python 3.12.
Python 3.12 is currently used on Google Colab. This PR fixes the issue.